### PR TITLE
Admin panel bug fixes and improvements

### DIFF
--- a/src/learning/admin.py
+++ b/src/learning/admin.py
@@ -1,5 +1,6 @@
 """ Learning models admin settings """
 from django.contrib import admin
+from django.conf import settings
 from django.contrib.admin.decorators import register
 
 from .models import (
@@ -12,50 +13,88 @@ from .models import (
 class CategoryAdmin(admin.ModelAdmin):
     """ Category admin settings """
 
-    list_display = ('name', 'slug', 'parent_category', 'is_active', )
+    list_display = ('name', 'slug', 'parent_category', 'is_active',)
 
-    list_filter = ('is_active', )
+    readonly_fields = ('slug',)
 
-    search_fields = ('name', 'slug', )
+    list_filter = ('is_active',)
 
-    prepopulated_fields = {"slug": ("name", )}
+    search_fields = ('name', 'slug',)
 
 
 @register(Tutorial)
 class TutorialAdmin(admin.ModelAdmin):
     """ Tutorial admin settings """
 
+    def get_categories(self, obj: Tutorial) -> str:
+        """
+        @rtype: str
+        @param obj: Tutorial object
+        @return: category names
+        """
+        categories = [cat.name for cat in obj.categories.filter(is_active=True).only('name')]
+        return '، '.join(categories)
+    get_categories.short_description = 'دسته بندی ها'
+
     list_display = ('title', 'slug', 'user_views_count',
                     'likes_count', 'create_date', 'last_edit_date',
-                    'confirm_status', 'is_active',)
+                    'confirm_status', 'is_active', 'is_edited', 'get_categories')
 
     list_filter = ('create_date', 'last_edit_date',
-                   'confirm_status', 'is_active', )
+                   'confirm_status', 'is_active',)
 
     search_fields = ('title', 'short_description')
 
-    fields = ('title', 'slug', 'short_description', 'body',
-              'image', 'confirm_status', 'is_active', 'categories',)
+    fields = ('author', 'title', 'slug', 'short_description',
+              'body', 'image', 'confirm_status', 'categories',
+              'is_active', 'is_edited',)
 
-    prepopulated_fields = {"slug": ("title", )}
+    readonly_fields = ['slug', 'is_edited']
+
+    def get_readonly_fields(self, request, obj=None):
+        if not settings.DEBUG:
+            self.readonly_fields += ['author', 'title', 'slug',
+                                     'short_description', 'body', 'image']
+        return self.readonly_fields
+
+    def has_add_permission(self, request):
+        return settings.DEBUG
 
 
 @register(TutorialTag)
 class TutorialTagAdmin(admin.ModelAdmin):
     """ Tutorial admin settings """
-    search_fields = ('title', )
+    search_fields = ('title',)
+
+    def has_add_permission(self, request):
+        return settings.DEBUG
+
+    def has_change_permission(self, request, obj=None):
+        return settings.DEBUG
 
 
 @register(TutorialComment)
 class TutorialCommentAdmin(admin.ModelAdmin):
     """ TutorialComment admin settings """
-    list_display = ('title', 'create_date', 'last_edit_date', 'confirm_status',
+    list_display = ('title', 'parent_comment', 'create_date', 'last_edit_date', 'confirm_status',
                     'is_edited', 'allow_reply', 'notify_replies', 'is_active')
 
-    fields = ('title', 'body', 'confirm_status', 'is_edited',
-              'allow_reply', 'notify_replies', 'is_active', 'user', 'tutorial', 'parent_comment',)
+    fields = ['user', 'tutorial', 'parent_comment',
+              'title', 'body', 'confirm_status', 'allow_reply',
+              'notify_replies', 'is_active']
 
     list_filter = ('create_date', 'last_edit_date', 'confirm_status',
                    'is_edited', 'allow_reply', 'notify_replies', 'is_active',)
 
-    search_fields = ('title', 'body', )
+    search_fields = ('title', 'body',)
+
+    readonly_fields = []
+
+    def get_readonly_fields(self, request, obj=None):
+        if not settings.DEBUG:
+            self.readonly_fields += ['user', 'tutorial', 'parent_comment',
+                                     'title', 'body']
+        return self.readonly_fields
+
+    def has_add_permission(self, request):
+        return settings.DEBUG

--- a/src/learning/templatetags/home_page_templatetags.py
+++ b/src/learning/templatetags/home_page_templatetags.py
@@ -1,6 +1,7 @@
 """ Home page template tag """
 from django import template
 from django.db.models import Count, Q
+
 from learning.models import Tutorial
 
 register = template.Library()
@@ -16,8 +17,7 @@ def get_tutorials(ordering: tuple, count: int):
         [TutorialQuerySet]: tutorials ordered by given ordering and
         sliced by given count
     """
-    tutorials = Tutorial.objects.confirmed_tutorials().filter(
-        is_active=True).order_by(*ordering).only(
+    tutorials = Tutorial.objects.active_and_confirmed_tutorials().order_by(*ordering).only(
         'title', 'slug', 'short_description', 'likes_count', 'image')[:count].annotate(
         comments_count=Count('comments', filter=Q(comments__confirm_status=1)))
 


### PR DESCRIPTION
learning project admin panel settings =>

 * creating tutorial, tutorial comment and tutorial tag only allowed on debug mode

 * changing tutorial tag only allowed on debug mode

 * tutorial and tutorial comment sensitive fields (like user, tutorial, title, ...) made read-only when DEBUG is false

 * tutorial and category slug removed (will automatically generate by title on save)

 * tutorial get_categories created

 * tutorial list_display => is_edited and get_categories added

 * tutorial comment list_display parent_comment added